### PR TITLE
Add permalinks for GeoJSON and WMS Labs (persist UI state in URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Labs kan till exempel användas för att:
 - validera JSON och metadata
 - testa format och strukturer
 - visualisera och förstå dataflöden
+- förhandsvisa GeoJSON + CSV på mörk basemap med export (GeoJSON Preview Map)
+- förhandsvisa WMS-lager via GetCapabilities med lagerlista (WMS Preview)
 
 Labs är inte färdiga produkter. De är till för att utforska, prova och lära.
 

--- a/site/src/pages/labs.astro
+++ b/site/src/pages/labs.astro
@@ -122,6 +122,62 @@ const base = import.meta.env.BASE_URL;
     <article class="module">
       <div class="module-head">
         <div class="module-title">
+          <span class="module-icon" aria-hidden="true">◎</span>
+          <div>
+            <h2 class="module-h">GeoJSON Preview Map</h2>
+            <p class="module-sub mono">MapLibre · Dark · Static</p>
+          </div>
+        </div>
+        <div class="module-meta">
+          <Badge label="IN ORBIT" variant="orbit" icon="orbit" />
+          <span class="module-route">/labs/geojson-preview</span>
+        </div>
+      </div>
+
+      <p class="module-desc">
+        Förhandsvisa GeoJSON direkt i webbläsaren med mörk basemap, export och attributpanel.
+      </p>
+
+      <div class="module-status mono">
+        STATUS: <span class="ok">READY</span> · Open now
+      </div>
+
+      <a class="btn secondary" href={`${base}labs/geojson-preview/`}>
+        Open GeoJSON Preview
+      </a>
+    </article>
+
+    <article class="module">
+      <div class="module-head">
+        <div class="module-title">
+          <span class="module-icon" aria-hidden="true">≋</span>
+          <div>
+            <h2 class="module-h">WMS Preview</h2>
+            <p class="module-sub mono">GetCapabilities · Overlay</p>
+          </div>
+        </div>
+        <div class="module-meta">
+          <Badge label="IN ORBIT" variant="orbit" icon="orbit" />
+          <span class="module-route">/labs/wms-preview</span>
+        </div>
+      </div>
+
+      <p class="module-desc">
+        Förhandsvisa WMS-lager utan backend: hämta GetCapabilities och rendera lagret som overlay.
+      </p>
+
+      <div class="module-status mono">
+        STATUS: <span class="ok">READY</span> · Open now
+      </div>
+
+      <a class="btn secondary" href={`${base}labs/wms-preview/`}>
+        Open WMS Preview
+      </a>
+    </article>
+
+    <article class="module">
+      <div class="module-head">
+        <div class="module-title">
           <span class="module-icon" aria-hidden="true">⟡</span>
           <div>
             <h2 class="module-h">Data Visualizations</h2>

--- a/site/src/pages/labs/geojson-preview.astro
+++ b/site/src/pages/labs/geojson-preview.astro
@@ -1,0 +1,1232 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout
+  title="GeoJSON Preview Map · Labs"
+  description="Preview GeoJSON instantly in your browser with a dark MapLibre basemap."
+>
+  <head>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.css"
+    />
+  </head>
+
+  <header class="lab-hero">
+    <p class="lab-kicker">LABS / GEOJSON</p>
+    <h1 class="lab-title">GeoJSON Preview Map</h1>
+    <p class="lab-subtitle">Preview GeoJSON instantly in your browser.</p>
+
+    <div class="lab-actions">
+      <a class="btn secondary" href={`${base}labs/`}>Back to Labs</a>
+      <button class="btn ghost" id="sampleBtn" type="button">Load Sample GeoJSON</button>
+    </div>
+  </header>
+
+  <section class="lab-shell" aria-label="GeoJSON preview workspace">
+    <div class="lab-panel">
+      <div class="lab-panel__head">
+        <div>
+          <p class="panel-kicker mono">INPUT MODES</p>
+          <h2 class="panel-title">Load your GeoJSON</h2>
+        </div>
+        <div class="panel-actions">
+          <button class="btn secondary" id="exportBtn" type="button">Export</button>
+          <button class="btn ghost" id="clearBtn" type="button">Clear</button>
+        </div>
+      </div>
+
+      <div class="lab-tabs" role="tablist" aria-label="GeoJSON input modes">
+        <button
+          class="lab-tab active"
+          id="tab-paste"
+          role="tab"
+          aria-selected="true"
+          aria-controls="panel-paste"
+          type="button"
+        >
+          Paste
+        </button>
+        <button
+          class="lab-tab"
+          id="tab-upload"
+          role="tab"
+          aria-selected="false"
+          aria-controls="panel-upload"
+          type="button"
+        >
+          Upload
+        </button>
+        <button
+          class="lab-tab"
+          id="tab-url"
+          role="tab"
+          aria-selected="false"
+          aria-controls="panel-url"
+          type="button"
+        >
+          URL
+        </button>
+        <button
+          class="lab-tab"
+          id="tab-csv"
+          role="tab"
+          aria-selected="false"
+          aria-controls="panel-csv"
+          type="button"
+        >
+          CSV
+        </button>
+      </div>
+
+      <div class="lab-tabpanels">
+        <section
+          class="lab-tabpanel active"
+          id="panel-paste"
+          role="tabpanel"
+          aria-labelledby="tab-paste"
+          tabindex="0"
+        >
+          <label class="field-label" for="geojsonInput">Paste GeoJSON</label>
+          <textarea
+            id="geojsonInput"
+            class="lab-textarea"
+            rows="10"
+            placeholder="{\n  \"type\": \"FeatureCollection\",\n  \"features\": []\n}"
+          ></textarea>
+          <div class="field-actions">
+            <button class="btn cta" id="loadPasteBtn" type="button">Load</button>
+          </div>
+        </section>
+
+        <section
+          class="lab-tabpanel"
+          id="panel-upload"
+          role="tabpanel"
+          aria-labelledby="tab-upload"
+          tabindex="0"
+        >
+          <label class="field-label" for="geojsonFile">Upload GeoJSON file</label>
+          <input
+            id="geojsonFile"
+            class="lab-file"
+            type="file"
+            accept=".geojson,.json,application/geo+json,application/json"
+          />
+          <p class="field-hint">
+            Supports <span class="mono">.geojson</span> or <span class="mono">.json</span>.
+          </p>
+        </section>
+
+        <section
+          class="lab-tabpanel"
+          id="panel-url"
+          role="tabpanel"
+          aria-labelledby="tab-url"
+          tabindex="0"
+        >
+          <label class="field-label" for="geojsonUrl">Load from URL</label>
+          <div class="field-row">
+            <input
+              id="geojsonUrl"
+              class="lab-input"
+              type="url"
+              placeholder="https://example.com/data.geojson"
+            />
+            <button class="btn cta" id="loadUrlBtn" type="button">Fetch</button>
+          </div>
+          <p class="field-hint">
+            If CORS blocks the request, download the file and use Upload or paste the contents instead.
+          </p>
+        </section>
+
+        <section
+          class="lab-tabpanel"
+          id="panel-csv"
+          role="tabpanel"
+          aria-labelledby="tab-csv"
+          tabindex="0"
+        >
+          <label class="field-label" for="csvInput">Paste CSV</label>
+          <textarea
+            id="csvInput"
+            class="lab-textarea"
+            rows="8"
+            placeholder="name,lat,lon\nPoint A,59.3293,18.0686\nPoint B,57.7089,11.9746"
+          ></textarea>
+          <div class="field-actions">
+            <button class="btn cta" id="loadCsvBtn" type="button">Load CSV</button>
+          </div>
+          <label class="field-label" for="csvFile">Upload CSV file</label>
+          <input id="csvFile" class="lab-file" type="file" accept=".csv,text/csv" />
+          <p class="field-hint">CSV headers are required. Use comma-separated values.</p>
+        </section>
+      </div>
+
+      <div class="lab-status" aria-live="polite">
+        <div>
+          <span class="status-label">Features</span>
+          <span id="statusCount">0</span>
+        </div>
+        <div>
+          <span class="status-label">Geometry</span>
+          <span id="statusTypes">-</span>
+        </div>
+        <div>
+          <span class="status-label">Extent</span>
+          <span id="statusExtent">-</span>
+        </div>
+        <div class="status-pill" id="statusMessage">Idle</div>
+      </div>
+
+      <div class="lab-alert" id="alert" role="alert" hidden></div>
+      <div class="lab-warning" id="warning" role="status" hidden></div>
+      <div class="lab-detect" id="detectBox" hidden>
+        <div>
+          <p class="detect-title">Detected columns</p>
+          <p class="detect-sub">
+            We found a JSON array of objects. Choose which fields represent latitude/longitude (or X/Y)
+            to convert into GeoJSON points.
+          </p>
+        </div>
+        <div class="detect-grid">
+          <label class="field-label" for="latField">Latitude / Y</label>
+          <select id="latField" class="lab-input"></select>
+          <label class="field-label" for="lonField">Longitude / X</label>
+          <select id="lonField" class="lab-input"></select>
+          <label class="field-label" for="nameField">Name (optional)</label>
+          <select id="nameField" class="lab-input"></select>
+        </div>
+        <div class="field-actions">
+          <button class="btn cta" id="convertBtn" type="button">Convert to GeoJSON</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="map-panel" aria-label="Map preview">
+      <div id="map" class="map"></div>
+      <aside class="info-panel" aria-live="polite">
+        <h3 class="info-title">Feature Attributes</h3>
+        <pre id="featureInfo" class="info-content">Click a feature to inspect attributes.</pre>
+      </aside>
+    </div>
+  </section>
+
+  <section class="lab-notes">
+    <h2 class="notes-title">How it works</h2>
+    <ul>
+      <li>GeoJSON is normalized into a FeatureCollection before rendering.</li>
+      <li>Points, lines, and polygons get distinct dark-mode styles.</li>
+      <li>All processing happens locally in your browser.</li>
+    </ul>
+  </section>
+
+  <script is:inline>
+    const MAPLIBRE_SRC = 'https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.js';
+
+    const loadScriptOnce = (src) =>
+      new Promise((resolve, reject) => {
+        if (window.maplibregl) return resolve(window.maplibregl);
+
+        const existing = document.querySelector('script[data-maplibre="true"]');
+        if (existing) {
+          existing.addEventListener('load', () => resolve(window.maplibregl));
+          existing.addEventListener('error', reject);
+          return;
+        }
+
+        const script = document.createElement('script');
+        script.src = src;
+        script.async = true;
+        script.defer = true;
+        script.dataset.maplibre = 'true';
+        script.onload = () => resolve(window.maplibregl);
+        script.onerror = () => reject(new Error('Failed to load MapLibre script.'));
+        document.head.appendChild(script);
+      });
+
+    const start = (maplibregl) => {
+      if (!maplibregl) throw new Error('MapLibre not available after load.');
+
+      const map = new maplibregl.Map({
+        container: 'map',
+        style: {
+          version: 8,
+          sources: {
+            dark: {
+              type: 'raster',
+              tiles: [
+                'https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+              ],
+              tileSize: 256,
+              attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+            },
+          },
+          layers: [
+            {
+              id: 'dark',
+              type: 'raster',
+              source: 'dark',
+            },
+          ],
+        },
+        center: [15.0, 62.0],
+        zoom: 4,
+        maxZoom: 18,
+      });
+
+      map.addControl(new maplibregl.NavigationControl({ showCompass: false }));
+
+      const tabs = Array.from(document.querySelectorAll('.lab-tab'));
+      const panels = Array.from(document.querySelectorAll('.lab-tabpanel'));
+      const alertBox = document.getElementById('alert');
+      const warningBox = document.getElementById('warning');
+      const detectBox = document.getElementById('detectBox');
+      const latField = document.getElementById('latField');
+      const lonField = document.getElementById('lonField');
+      const nameField = document.getElementById('nameField');
+      const convertBtn = document.getElementById('convertBtn');
+      const statusCount = document.getElementById('statusCount');
+      const statusTypes = document.getElementById('statusTypes');
+      const statusExtent = document.getElementById('statusExtent');
+      const statusMessage = document.getElementById('statusMessage');
+      const featureInfo = document.getElementById('featureInfo');
+      const geojsonInput = document.getElementById('geojsonInput');
+      const geojsonFile = document.getElementById('geojsonFile');
+      const geojsonUrl = document.getElementById('geojsonUrl');
+      const csvInput = document.getElementById('csvInput');
+      const csvFile = document.getElementById('csvFile');
+      let currentCollection = null;
+      let detectedRecords = null;
+      const params = new URLSearchParams(window.location.search);
+
+      const sampleGeoJSON = {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: { name: 'Göteborg', role: 'Sample point' },
+            geometry: {
+              type: 'Point',
+              coordinates: [11.9746, 57.7089],
+            },
+          },
+          {
+            type: 'Feature',
+            properties: { name: 'Stockholm region', theme: 'Sample polygon' },
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [17.7, 59.6],
+                  [18.6, 59.6],
+                  [18.6, 59.1],
+                  [17.7, 59.1],
+                  [17.7, 59.6],
+                ],
+              ],
+            },
+          },
+        ],
+      };
+
+      const geometryGroups = {
+        point: ['Point', 'MultiPoint'],
+        line: ['LineString', 'MultiLineString'],
+        polygon: ['Polygon', 'MultiPolygon'],
+      };
+
+      const setStatus = (message) => {
+        statusMessage.textContent = message;
+      };
+
+      const showAlert = (message) => {
+        alertBox.hidden = false;
+        alertBox.textContent = message;
+      };
+
+      const showWarning = (message) => {
+        warningBox.hidden = false;
+        warningBox.textContent = message;
+      };
+
+      const clearAlert = () => {
+        alertBox.hidden = true;
+        alertBox.textContent = '';
+        warningBox.hidden = true;
+        warningBox.textContent = '';
+      };
+
+      const clearDetected = () => {
+        detectBox.hidden = true;
+        latField.innerHTML = '';
+        lonField.innerHTML = '';
+        nameField.innerHTML = '';
+        detectedRecords = null;
+      };
+
+      const setParam = (key, value) => {
+        if (!value) {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+        const query = params.toString();
+        const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+        window.history.replaceState(null, '', nextUrl);
+      };
+
+      const restoreMapView = () => {
+        const centerParam = params.get('center');
+        const zoomParam = params.get('zoom');
+        if (!centerParam || !zoomParam) return;
+        const [lng, lat] = centerParam.split(',').map((value) => Number(value));
+        const zoom = Number(zoomParam);
+        if (!Number.isFinite(lng) || !Number.isFinite(lat) || !Number.isFinite(zoom)) return;
+        map.jumpTo({ center: [lng, lat], zoom });
+      };
+
+      const formatExtent = (extent) => {
+        if (!extent) return '-';
+        const [minX, minY, maxX, maxY] = extent;
+        return `${minX.toFixed(4)}, ${minY.toFixed(4)} → ${maxX.toFixed(4)}, ${maxY.toFixed(4)}`;
+      };
+
+      const collectCoordinates = (coords, list) => {
+        if (typeof coords[0] === 'number') {
+          list.push(coords);
+        } else {
+          coords.forEach((child) => collectCoordinates(child, list));
+        }
+      };
+
+      const getExtent = (features) => {
+        const coords = [];
+        features.forEach((feature) => {
+          if (!feature || !feature.geometry) return;
+          collectCoordinates(feature.geometry.coordinates, coords);
+        });
+
+        if (!coords.length) return null;
+
+        const xs = coords.map((coord) => coord[0]);
+        const ys = coords.map((coord) => coord[1]);
+        return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
+      };
+
+      // Normalize FeatureCollection/Feature/Geometry into a single FeatureCollection.
+      const normalizeGeoJSON = (input) => {
+        const warnings = [];
+        let features = [];
+
+        if (!input) {
+          return { errors: ['No data provided.'], warnings, collection: null };
+        }
+
+        if (Array.isArray(input)) {
+          features = input.filter((item) => item && item.type === 'Feature');
+        } else if (input.type === 'FeatureCollection') {
+          features = Array.isArray(input.features) ? input.features : [];
+        } else if (input.type === 'Feature') {
+          features = [input];
+        } else if (input.type && input.coordinates) {
+          features = [{ type: 'Feature', properties: {}, geometry: input }];
+        }
+
+        const validFeatures = [];
+        const invalidFeatures = [];
+
+        features.forEach((feature) => {
+          if (!feature || feature.type !== 'Feature') {
+            invalidFeatures.push(feature);
+            return;
+          }
+          if (!feature.geometry) {
+            invalidFeatures.push(feature);
+            return;
+          }
+          validFeatures.push({
+            type: 'Feature',
+            properties: feature.properties || {},
+            geometry: feature.geometry,
+          });
+        });
+
+        if (invalidFeatures.length) {
+          warnings.push(`Skipped ${invalidFeatures.length} feature(s) without geometry.`);
+        }
+
+        if (!validFeatures.length) {
+          return { errors: ['No valid GeoJSON features were found.'], warnings, collection: null };
+        }
+
+        return {
+          errors: [],
+          warnings,
+          collection: {
+            type: 'FeatureCollection',
+            features: validFeatures,
+          },
+        };
+      };
+
+      const summarizeTypes = (features) => {
+        const counts = { point: 0, line: 0, polygon: 0, other: 0 };
+        features.forEach((feature) => {
+          const type = feature.geometry?.type;
+          if (geometryGroups.point.includes(type)) counts.point += 1;
+          else if (geometryGroups.line.includes(type)) counts.line += 1;
+          else if (geometryGroups.polygon.includes(type)) counts.polygon += 1;
+          else counts.other += 1;
+        });
+        const parts = [];
+        if (counts.point) parts.push(`Point ${counts.point}`);
+        if (counts.line) parts.push(`Line ${counts.line}`);
+        if (counts.polygon) parts.push(`Polygon ${counts.polygon}`);
+        if (counts.other) parts.push(`Other ${counts.other}`);
+        return parts.length ? parts.join(' · ') : '-';
+      };
+
+      const updateStatus = (features, extent) => {
+        statusCount.textContent = features.length.toString();
+        statusTypes.textContent = summarizeTypes(features);
+        statusExtent.textContent = formatExtent(extent);
+      };
+
+      const updateWarningForSize = (featureCount) => {
+        if (featureCount > 20000) {
+          showWarning(
+            `Large dataset detected (${featureCount} features). Consider simplifying your GeoJSON for better performance.`
+          );
+        }
+      };
+
+      const resetInfoPanel = () => {
+        featureInfo.textContent = 'Click a feature to inspect attributes.';
+      };
+
+      const renderGeoJSON = (collection) => {
+        if (!map.getSource('geojson')) {
+          map.addSource('geojson', {
+            type: 'geojson',
+            data: collection,
+          });
+
+          map.addLayer({
+            id: 'geojson-fill',
+            type: 'fill',
+            source: 'geojson',
+            filter: ['in', ['geometry-type'], ['literal', geometryGroups.polygon]],
+            paint: {
+              'fill-color': 'rgba(88,166,255,0.25)',
+              'fill-outline-color': 'rgba(88,166,255,0.7)',
+            },
+          });
+
+          map.addLayer({
+            id: 'geojson-line',
+            type: 'line',
+            source: 'geojson',
+            filter: ['in', ['geometry-type'], ['literal', geometryGroups.line]],
+            paint: {
+              'line-color': 'rgba(160, 214, 255, 0.85)',
+              'line-width': 2,
+            },
+          });
+
+          map.addLayer({
+            id: 'geojson-point',
+            type: 'circle',
+            source: 'geojson',
+            filter: ['in', ['geometry-type'], ['literal', geometryGroups.point]],
+            paint: {
+              'circle-color': 'rgba(246, 217, 110, 0.92)',
+              'circle-stroke-color': 'rgba(12, 18, 30, 0.85)',
+              'circle-stroke-width': 1.2,
+              'circle-radius': 6,
+            },
+          });
+
+          ['geojson-fill', 'geojson-line', 'geojson-point'].forEach((layer) => {
+            map.on('mouseenter', layer, () => {
+              map.getCanvas().style.cursor = 'pointer';
+            });
+            map.on('mouseleave', layer, () => {
+              map.getCanvas().style.cursor = '';
+            });
+            map.on('click', layer, (event) => {
+              const feature = event.features?.[0];
+              if (!feature) return;
+              const props = feature.properties || {};
+              const content = Object.keys(props).length
+                ? JSON.stringify(props, null, 2)
+                : 'No attributes';
+              featureInfo.textContent = content;
+            });
+          });
+        } else {
+          map.getSource('geojson').setData(collection);
+        }
+      };
+
+      const removeGeoJSON = () => {
+        if (map.getLayer('geojson-point')) map.removeLayer('geojson-point');
+        if (map.getLayer('geojson-line')) map.removeLayer('geojson-line');
+        if (map.getLayer('geojson-fill')) map.removeLayer('geojson-fill');
+        if (map.getSource('geojson')) map.removeSource('geojson');
+      };
+
+      // Zoom to the data extent after render.
+      const fitToExtent = (extent) => {
+        if (!extent) return;
+        map.fitBounds(
+          [
+            [extent[0], extent[1]],
+            [extent[2], extent[3]],
+          ],
+          { padding: 60, duration: 650 }
+        );
+      };
+
+      const handleGeoJSON = (payload, sourceLabel = 'Loaded') => {
+        clearAlert();
+        clearDetected();
+        resetInfoPanel();
+
+        const { errors, warnings, collection } = normalizeGeoJSON(payload);
+        if (errors.length) {
+          showAlert(errors.join(' '));
+          setStatus('Error');
+          return;
+        }
+
+        warnings.forEach((warning) => showWarning(warning));
+        updateWarningForSize(collection.features.length);
+
+        currentCollection = collection;
+        renderGeoJSON(collection);
+        const extent = getExtent(collection.features);
+        updateStatus(collection.features, extent);
+        fitToExtent(extent);
+        setStatus(sourceLabel);
+      };
+
+      const handleTextInput = (text, sourceLabel) => {
+        if (!text.trim()) {
+          showAlert('Please provide GeoJSON before loading.');
+          setStatus('Idle');
+          return;
+        }
+
+        let parsed;
+        try {
+          parsed = JSON.parse(text);
+        } catch (error) {
+          showAlert(`JSON parse error: ${error.message}`);
+          setStatus('Error');
+          return;
+        }
+
+        if (Array.isArray(parsed) && parsed.every((item) => item && typeof item === 'object' && !item.type)) {
+          handleRecordArray(parsed, 'JSON array detected. Select coordinate fields to convert to GeoJSON.');
+          setStatus('Awaiting mapping');
+          return;
+        }
+
+        handleGeoJSON(parsed, sourceLabel);
+      };
+
+      const splitCsvLine = (line) => {
+        const cells = [];
+        let current = '';
+        let inQuotes = false;
+        for (let i = 0; i < line.length; i += 1) {
+          const char = line[i];
+          if (char === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+              current += '"';
+              i += 1;
+            } else {
+              inQuotes = !inQuotes;
+            }
+          } else if (char === ',' && !inQuotes) {
+            cells.push(current);
+            current = '';
+          } else {
+            current += char;
+          }
+        }
+        cells.push(current);
+        return cells.map((cell) => cell.trim());
+      };
+
+      const parseCsv = (text) => {
+        const lines = text
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean);
+        if (!lines.length) return [];
+        const headers = splitCsvLine(lines[0]).filter(Boolean);
+        if (!headers.length) return [];
+        return lines.slice(1).map((line) => {
+          const values = splitCsvLine(line);
+          return headers.reduce((acc, header, idx) => {
+            acc[header] = values[idx] ?? '';
+            return acc;
+          }, {});
+        });
+      };
+
+      const handleCsvInput = (text) => {
+        if (!text.trim()) {
+          showAlert('Please provide CSV data before loading.');
+          setStatus('Idle');
+          return;
+        }
+        const records = parseCsv(text);
+        if (!records.length) {
+          showAlert('No CSV rows were detected. Ensure the first line contains headers.');
+          setStatus('Error');
+          return;
+        }
+        handleRecordArray(records, 'CSV detected. Select coordinate fields to convert to GeoJSON.');
+        setStatus('Awaiting mapping');
+      };
+
+      const loadCsvFromFile = (file) => {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = (event) => {
+          const text = event.target?.result || '';
+          handleCsvInput(String(text));
+        };
+        reader.onerror = () => {
+          showAlert('Unable to read the selected CSV file.');
+          setStatus('Error');
+        };
+        reader.readAsText(file);
+      };
+
+      const handleRecordArray = (records, hintMessage) => {
+        const keys = Array.from(new Set(records.flatMap((row) => Object.keys(row || {}))));
+        if (!keys.length) {
+          showAlert('No fields were detected in the uploaded data.');
+          setStatus('Error');
+          return;
+        }
+        detectedRecords = records;
+        const options = keys.map((key) => `<option value="${key}">${key}</option>`).join('');
+        latField.innerHTML = options;
+        lonField.innerHTML = options;
+        nameField.innerHTML = `<option value="">None</option>${options}`;
+        const autoLat = keys.find((key) => /^(lat|latitude|y)$/i.test(key));
+        const autoLon = keys.find((key) => /^(lon|lng|longitude|x)$/i.test(key));
+        const autoName = keys.find((key) => /^(name|title|label)$/i.test(key));
+        if (autoLat) latField.value = autoLat;
+        if (autoLon) lonField.value = autoLon;
+        if (autoName) nameField.value = autoName;
+        detectBox.hidden = false;
+        showWarning(hintMessage);
+      };
+
+      const convertDetected = () => {
+        if (!detectedRecords) {
+          showAlert('No JSON records available for conversion.');
+          return;
+        }
+        const latKey = latField.value;
+        const lonKey = lonField.value;
+        const nameKey = nameField.value;
+        if (!latKey || !lonKey) {
+          showAlert('Please select both latitude and longitude fields.');
+          return;
+        }
+
+        const features = [];
+        let skipped = 0;
+        detectedRecords.forEach((row) => {
+          const lat = Number(row?.[latKey]);
+          const lon = Number(row?.[lonKey]);
+          if (Number.isFinite(lat) && Number.isFinite(lon)) {
+            const props = { ...row };
+            delete props[latKey];
+            delete props[lonKey];
+            if (nameKey) {
+              const nameValue = row?.[nameKey];
+              delete props[nameKey];
+              if (nameValue !== undefined) props.name = nameValue;
+            }
+            features.push({
+              type: 'Feature',
+              properties: props,
+              geometry: {
+                type: 'Point',
+                coordinates: [lon, lat],
+              },
+            });
+          } else {
+            skipped += 1;
+          }
+        });
+
+        if (!features.length) {
+          showAlert('No valid coordinates found. Check the selected fields.');
+          setStatus('Error');
+          return;
+        }
+
+        if (skipped) {
+          showWarning(`Skipped ${skipped} row(s) without valid coordinates.`);
+        }
+
+        handleGeoJSON({ type: 'FeatureCollection', features }, 'Converted JSON');
+      };
+
+      const loadFromFile = (file) => {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = (event) => {
+          const text = event.target?.result || '';
+          handleTextInput(String(text), 'File loaded');
+        };
+        reader.onerror = () => {
+          showAlert('Unable to read the selected file.');
+          setStatus('Error');
+        };
+        reader.readAsText(file);
+      };
+
+      const loadFromUrl = async () => {
+        const url = geojsonUrl.value.trim();
+        if (!url) {
+          showAlert('Please enter a URL to fetch.');
+          setStatus('Idle');
+          return;
+        }
+
+        setStatus('Fetching');
+        clearAlert();
+
+        try {
+          const response = await fetch(url, { mode: 'cors' });
+          if (!response.ok) {
+            showAlert(`Fetch failed with status ${response.status} ${response.statusText}.`);
+            setStatus('Error');
+            return;
+          }
+          const text = await response.text();
+          handleTextInput(text, 'URL loaded');
+        } catch (error) {
+          // CORS/network errors surface as TypeError; guide the user to other inputs.
+          const fallbackMessage =
+            error instanceof TypeError
+              ? 'CORS blocked the request. Download the file and use Upload, or paste the contents.'
+              : 'Network error while fetching the URL.';
+          showAlert(
+            `${fallbackMessage} (${error?.name || 'Error'})`
+          );
+          setStatus('Error');
+        }
+      };
+
+      const downloadCollection = () => {
+        if (!currentCollection) {
+          showAlert('Nothing to export yet. Load GeoJSON first.');
+          setStatus('Idle');
+          return;
+        }
+        const blob = new Blob([JSON.stringify(currentCollection, null, 2)], {
+          type: 'application/geo+json',
+        });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'data.geojson';
+        link.click();
+        URL.revokeObjectURL(url);
+      };
+
+      const clearAll = () => {
+        removeGeoJSON();
+        currentCollection = null;
+        detectedRecords = null;
+        geojsonInput.value = '';
+        geojsonFile.value = '';
+        geojsonUrl.value = '';
+        csvInput.value = '';
+        csvFile.value = '';
+        setParam('url', '');
+        updateStatus([], null);
+        clearAlert();
+        clearDetected();
+        resetInfoPanel();
+        setStatus('Idle');
+        map.easeTo({ center: [15.0, 62.0], zoom: 4, duration: 400 });
+      };
+
+      const switchTab = (tab) => {
+        tabs.forEach((btn) => {
+          btn.classList.toggle('active', btn === tab);
+          btn.setAttribute('aria-selected', btn === tab);
+        });
+        panels.forEach((panel) => {
+          panel.classList.toggle('active', panel.id === tab.getAttribute('aria-controls'));
+        });
+        tab.focus();
+        const tabKey = tab.id?.replace('tab-', '');
+        if (tabKey) setParam('tab', tabKey);
+      };
+
+      tabs.forEach((tab) => {
+        tab.addEventListener('click', () => switchTab(tab));
+        tab.addEventListener('keydown', (event) => {
+          if (!['ArrowLeft', 'ArrowRight'].includes(event.key)) return;
+          event.preventDefault();
+          const currentIndex = tabs.indexOf(tab);
+          const nextIndex = event.key === 'ArrowRight'
+            ? (currentIndex + 1) % tabs.length
+            : (currentIndex - 1 + tabs.length) % tabs.length;
+          switchTab(tabs[nextIndex]);
+        });
+      });
+
+      document.getElementById('loadPasteBtn').addEventListener('click', () => {
+        handleTextInput(geojsonInput.value, 'Paste loaded');
+      });
+
+      document.getElementById('loadUrlBtn').addEventListener('click', () => {
+        setParam('url', geojsonUrl.value.trim());
+        loadFromUrl();
+      });
+
+      document.getElementById('loadCsvBtn').addEventListener('click', () => {
+        handleCsvInput(csvInput.value);
+      });
+
+      document.getElementById('sampleBtn').addEventListener('click', () => {
+        geojsonInput.value = JSON.stringify(sampleGeoJSON, null, 2);
+        switchTab(document.getElementById('tab-paste'));
+        handleGeoJSON(sampleGeoJSON, 'Sample loaded');
+      });
+
+      document.getElementById('exportBtn').addEventListener('click', downloadCollection);
+      document.getElementById('clearBtn').addEventListener('click', clearAll);
+      convertBtn.addEventListener('click', convertDetected);
+
+      geojsonFile.addEventListener('change', (event) => {
+        const file = event.target.files?.[0];
+        loadFromFile(file);
+      });
+
+      csvFile.addEventListener('change', (event) => {
+        const file = event.target.files?.[0];
+        loadCsvFromFile(file);
+      });
+
+      geojsonUrl.addEventListener('change', () => {
+        setParam('url', geojsonUrl.value.trim());
+      });
+
+      map.on('moveend', () => {
+        const center = map.getCenter();
+        setParam('center', `${center.lng.toFixed(5)},${center.lat.toFixed(5)}`);
+        setParam('zoom', map.getZoom().toFixed(2));
+      });
+
+      map.on('load', () => {
+        restoreMapView();
+        setStatus('Idle');
+      });
+
+      const savedTab = params.get('tab');
+      if (savedTab) {
+        const tabButton = document.getElementById(`tab-${savedTab}`);
+        if (tabButton) switchTab(tabButton);
+      }
+      const savedUrl = params.get('url');
+      if (savedUrl) geojsonUrl.value = savedUrl;
+    };
+
+    const boot = async () => {
+      try {
+        const maplibregl = await loadScriptOnce(MAPLIBRE_SRC);
+        start(maplibregl);
+      } catch (error) {
+        console.error(error);
+        const alertBox = document.getElementById('alert');
+        if (alertBox) {
+          alertBox.hidden = false;
+          alertBox.textContent = 'Failed to initialize MapLibre. Check console for details.';
+        }
+      }
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', boot);
+    } else {
+      boot();
+    }
+  </script>
+</Layout>
+
+<style>
+.lab-hero{
+  text-align: center;
+  padding: var(--spacing-xl) 0 var(--spacing-lg);
+}
+.lab-kicker{
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(88,166,255,0.8);
+  margin-bottom: 8px;
+}
+.lab-title{
+  margin: 0 0 8px;
+  font-family: var(--font-display);
+  letter-spacing: 0.03em;
+}
+.lab-subtitle{
+  margin: 0 auto;
+  color: rgba(230,237,243,0.72);
+  max-width: 60ch;
+}
+.lab-actions{
+  margin-top: var(--spacing-md);
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.lab-shell{
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) 1fr;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+@media (max-width: 980px){
+  .lab-shell{ grid-template-columns: 1fr; }
+}
+
+.lab-panel{
+  border-radius: 18px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(13,17,23,0.55);
+  padding: var(--spacing-md);
+  box-shadow: 0 20px 55px rgba(0,0,0,0.28);
+}
+.lab-panel__head{
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.panel-kicker{
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(88,166,255,0.72);
+  margin: 0 0 6px;
+}
+.panel-title{
+  margin: 0;
+  font-size: 1.2rem;
+}
+.panel-actions{ display:flex; gap: 8px; flex-wrap: wrap; }
+
+.lab-tabs{
+  display: flex;
+  gap: 8px;
+  margin-top: var(--spacing-md);
+  flex-wrap: wrap;
+}
+.lab-tab{
+  border: 1px solid rgba(88,166,255,0.2);
+  background: rgba(13,17,23,0.3);
+  color: rgba(230,237,243,0.7);
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.lab-tab.active{
+  border-color: rgba(88,166,255,0.4);
+  color: rgba(88,166,255,0.95);
+}
+
+.lab-tabpanels{
+  margin-top: var(--spacing-md);
+}
+.lab-tabpanel{ display: none; }
+.lab-tabpanel.active{ display: block; }
+
+.field-label{
+  display: block;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.lab-textarea{
+  width: 100%;
+  background: rgba(13,17,23,0.4);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 12px;
+  padding: 12px;
+  color: rgba(230,237,243,0.9);
+  font-family: var(--font-mono);
+}
+.lab-input,
+.lab-file{
+  width: 100%;
+  background: rgba(13,17,23,0.4);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: rgba(230,237,243,0.9);
+}
+.field-row{
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.field-row .lab-input{ flex: 1 1 220px; }
+.field-actions{ margin-top: 10px; }
+.field-hint{
+  margin-top: 8px;
+  color: rgba(230,237,243,0.55);
+  font-size: 0.85rem;
+}
+
+.lab-status{
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+  margin-top: var(--spacing-md);
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(88,166,255,0.16);
+  background: rgba(13,17,23,0.35);
+  font-size: 0.85rem;
+}
+.status-label{
+  display: block;
+  color: rgba(88,166,255,0.72);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.status-pill{
+  align-self: center;
+  justify-self: end;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(13,17,23,0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
+}
+
+.lab-alert,
+.lab-warning{
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 90, 90, 0.3);
+  background: rgba(120, 20, 20, 0.2);
+  color: rgba(255, 200, 200, 0.9);
+  font-size: 0.9rem;
+}
+.lab-warning{
+  border-color: rgba(246, 217, 110, 0.4);
+  background: rgba(60, 50, 18, 0.35);
+  color: rgba(246, 217, 110, 0.92);
+}
+
+.lab-detect{
+  margin-top: 12px;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(88,166,255,0.25);
+  background: rgba(13,17,23,0.45);
+}
+.detect-title{
+  margin: 0 0 6px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(88,166,255,0.8);
+}
+.detect-sub{
+  margin: 0 0 12px;
+  color: rgba(230,237,243,0.7);
+  font-size: 0.85rem;
+}
+.detect-grid{
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+@media (min-width: 640px){
+  .detect-grid{ grid-template-columns: auto 1fr; align-items: center; }
+}
+
+.map-panel{
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(13,17,23,0.5);
+  min-height: 520px;
+}
+.map{
+  width: 100%;
+  height: 520px;
+}
+.info-panel{
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  max-width: 320px;
+  background: rgba(13,17,23,0.82);
+  border: 1px solid rgba(88,166,255,0.2);
+  border-radius: 14px;
+  padding: 12px;
+  color: rgba(230,237,243,0.85);
+  box-shadow: 0 12px 40px rgba(0,0,0,0.35);
+}
+.info-title{
+  margin: 0 0 6px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(88,166,255,0.8);
+}
+.info-content{
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+}
+
+.lab-notes{
+  margin-top: var(--spacing-xl);
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(13,17,23,0.45);
+  padding: var(--spacing-md);
+}
+.notes-title{
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+</style>

--- a/site/src/pages/labs/wms-preview.astro
+++ b/site/src/pages/labs/wms-preview.astro
@@ -1,0 +1,607 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout
+  title="WMS Preview · Labs"
+  description="Preview WMS layers on a dark basemap without any backend."
+>
+  <head>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.css"
+    />
+  </head>
+
+  <header class="lab-hero">
+    <p class="lab-kicker">LABS / WMS</p>
+    <h1 class="lab-title">WMS Preview</h1>
+    <p class="lab-subtitle">
+      Load a WMS GetCapabilities document, choose a layer, and preview it on a dark basemap.
+    </p>
+
+    <div class="lab-actions">
+      <a class="btn secondary" href={`${base}labs/`}>Back to Labs</a>
+    </div>
+  </header>
+
+  <section class="lab-shell" aria-label="WMS preview workspace">
+    <div class="lab-panel">
+      <div class="lab-panel__head">
+        <div>
+          <p class="panel-kicker mono">WMS INPUT</p>
+          <h2 class="panel-title">Load GetCapabilities</h2>
+        </div>
+      </div>
+
+      <label class="field-label" for="wmsUrl">WMS URL</label>
+      <div class="field-row">
+        <input
+          id="wmsUrl"
+          class="lab-input"
+          type="url"
+          placeholder="https://example.com/geoserver/wms?service=WMS&request=GetCapabilities"
+        />
+        <button class="btn cta" id="loadWmsBtn" type="button">Fetch</button>
+      </div>
+      <p class="field-hint">
+        If CORS blocks the request, open the URL in a new tab and ensure it allows cross-origin access.
+      </p>
+
+      <div class="lab-status" aria-live="polite">
+        <div>
+          <span class="status-label">Layers</span>
+          <span id="statusLayers">0</span>
+        </div>
+        <div>
+          <span class="status-label">Selected</span>
+          <span id="statusSelected">-</span>
+        </div>
+        <div class="status-pill" id="statusMessage">Idle</div>
+      </div>
+
+      <div class="lab-alert" id="alert" role="alert" hidden></div>
+      <div class="lab-warning" id="warning" role="status" hidden></div>
+
+      <div class="layer-list" id="layerList" hidden>
+        <p class="list-title">Available layers</p>
+        <div id="layerItems" class="list-items" role="radiogroup" aria-label="WMS layers"></div>
+      </div>
+    </div>
+
+    <div class="map-panel" aria-label="Map preview">
+      <div id="map" class="map"></div>
+      <aside class="info-panel" aria-live="polite">
+        <h3 class="info-title">Layer Info</h3>
+        <pre id="layerInfo" class="info-content">Select a layer to render it on the map.</pre>
+      </aside>
+    </div>
+  </section>
+
+  <script is:inline>
+    const MAPLIBRE_SRC = 'https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.js';
+
+    const loadScriptOnce = (src) =>
+      new Promise((resolve, reject) => {
+        if (window.maplibregl) return resolve(window.maplibregl);
+
+        const existing = document.querySelector('script[data-maplibre="true"]');
+        if (existing) {
+          existing.addEventListener('load', () => resolve(window.maplibregl));
+          existing.addEventListener('error', reject);
+          return;
+        }
+
+        const script = document.createElement('script');
+        script.src = src;
+        script.async = true;
+        script.defer = true;
+        script.dataset.maplibre = 'true';
+        script.onload = () => resolve(window.maplibregl);
+        script.onerror = () => reject(new Error('Failed to load MapLibre script.'));
+        document.head.appendChild(script);
+      });
+
+    const start = (maplibregl) => {
+      if (!maplibregl) throw new Error('MapLibre not available after load.');
+
+      const map = new maplibregl.Map({
+        container: 'map',
+        style: {
+          version: 8,
+          sources: {
+            dark: {
+              type: 'raster',
+              tiles: ['https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'],
+              tileSize: 256,
+              attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+            },
+          },
+          layers: [{ id: 'dark', type: 'raster', source: 'dark' }],
+        },
+        center: [15.0, 62.0],
+        zoom: 4,
+        maxZoom: 18,
+      });
+
+      map.addControl(new maplibregl.NavigationControl({ showCompass: false }));
+
+      const wmsUrlInput = document.getElementById('wmsUrl');
+      const loadWmsBtn = document.getElementById('loadWmsBtn');
+      const statusLayers = document.getElementById('statusLayers');
+      const statusSelected = document.getElementById('statusSelected');
+      const statusMessage = document.getElementById('statusMessage');
+      const alertBox = document.getElementById('alert');
+      const warningBox = document.getElementById('warning');
+      const layerList = document.getElementById('layerList');
+      const layerItems = document.getElementById('layerItems');
+      const layerInfo = document.getElementById('layerInfo');
+
+      let currentLayers = [];
+      let currentBaseUrl = '';
+      const params = new URLSearchParams(window.location.search);
+
+      const setStatus = (message) => {
+        statusMessage.textContent = message;
+      };
+
+      const showAlert = (message) => {
+        alertBox.hidden = false;
+        alertBox.textContent = message;
+      };
+
+      const showWarning = (message) => {
+        warningBox.hidden = false;
+        warningBox.textContent = message;
+      };
+
+      const clearMessages = () => {
+        alertBox.hidden = true;
+        alertBox.textContent = '';
+        warningBox.hidden = true;
+        warningBox.textContent = '';
+      };
+
+      const clearLayerList = () => {
+        layerItems.innerHTML = '';
+        layerList.hidden = true;
+        currentLayers = [];
+        statusLayers.textContent = '0';
+        statusSelected.textContent = '-';
+        layerInfo.textContent = 'Select a layer to render it on the map.';
+      };
+
+      const setParam = (key, value) => {
+        if (!value) {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+        const query = params.toString();
+        const nextUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+        window.history.replaceState(null, '', nextUrl);
+      };
+
+      const restoreMapView = () => {
+        const centerParam = params.get('center');
+        const zoomParam = params.get('zoom');
+        if (!centerParam || !zoomParam) return;
+        const [lng, lat] = centerParam.split(',').map((value) => Number(value));
+        const zoom = Number(zoomParam);
+        if (!Number.isFinite(lng) || !Number.isFinite(lat) || !Number.isFinite(zoom)) return;
+        map.jumpTo({ center: [lng, lat], zoom });
+      };
+
+      const buildCapabilitiesUrl = (rawUrl) => {
+        const url = new URL(rawUrl);
+        url.searchParams.set('service', 'WMS');
+        url.searchParams.set('request', 'GetCapabilities');
+        return url.toString();
+      };
+
+      const parseCapabilities = (xmlText) => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(xmlText, 'text/xml');
+        const error = doc.querySelector('parsererror');
+        if (error) {
+          throw new Error('Unable to parse GetCapabilities response.');
+        }
+        const layers = Array.from(doc.querySelectorAll('Layer > Name')).map((nameNode) => {
+          const layerNode = nameNode.parentElement;
+          const titleNode = layerNode?.querySelector('Title');
+          return {
+            name: nameNode.textContent?.trim() || '',
+            title: titleNode?.textContent?.trim() || '',
+          };
+        }).filter((layer) => layer.name);
+        return layers;
+      };
+
+      const buildWmsTiles = (baseUrl, layerName) => {
+        const url = new URL(baseUrl);
+        url.searchParams.set('service', 'WMS');
+        url.searchParams.set('request', 'GetMap');
+        url.searchParams.set('layers', layerName);
+        url.searchParams.set('styles', '');
+        url.searchParams.set('format', 'image/png');
+        url.searchParams.set('transparent', 'true');
+        url.searchParams.set('version', '1.3.0');
+        url.searchParams.set('crs', 'EPSG:3857');
+        url.searchParams.set('width', '256');
+        url.searchParams.set('height', '256');
+        url.searchParams.set('bbox', '{bbox-epsg-3857}');
+        return url.toString();
+      };
+
+      const renderLayer = (layer) => {
+        if (map.getLayer('wms-layer')) map.removeLayer('wms-layer');
+        if (map.getSource('wms-source')) map.removeSource('wms-source');
+
+        const tileUrl = buildWmsTiles(currentBaseUrl, layer.name);
+        map.addSource('wms-source', {
+          type: 'raster',
+          tiles: [tileUrl],
+          tileSize: 256,
+        });
+
+        map.addLayer({
+          id: 'wms-layer',
+          type: 'raster',
+          source: 'wms-source',
+        });
+
+        statusSelected.textContent = layer.title || layer.name;
+        layerInfo.textContent = layer.title
+          ? `${layer.title}\n(${layer.name})`
+          : layer.name;
+        setParam('layer', layer.name);
+      };
+
+      const populateLayers = (layers) => {
+        clearLayerList();
+        currentLayers = layers;
+        statusLayers.textContent = layers.length.toString();
+        if (!layers.length) {
+          showAlert('No named layers were found in the GetCapabilities response.');
+          setStatus('Idle');
+          return;
+        }
+
+        layerItems.innerHTML = layers
+          .map((layer, index) => {
+            const title = layer.title || layer.name;
+            return `
+              <label class="layer-item">
+                <input type="radio" name="wms-layer" value="${layer.name}" data-index="${index}" />
+                <span>${title}</span>
+              </label>
+            `;
+          })
+          .join('');
+        layerList.hidden = false;
+
+        const savedLayer = params.get('layer');
+        if (savedLayer) {
+          const selectedIndex = layers.findIndex((layer) => layer.name === savedLayer);
+          if (selectedIndex >= 0) {
+            const input = layerItems.querySelector(`input[data-index=\"${selectedIndex}\"]`);
+            if (input instanceof HTMLInputElement) {
+              input.checked = true;
+              renderLayer(layers[selectedIndex]);
+            }
+          }
+        }
+      };
+
+      const fetchCapabilities = async () => {
+        const rawUrl = wmsUrlInput.value.trim();
+        if (!rawUrl) {
+          showAlert('Please enter a WMS URL.');
+          setStatus('Idle');
+          return;
+        }
+        clearMessages();
+        clearLayerList();
+        setStatus('Fetching');
+
+        let capabilitiesUrl = rawUrl;
+        try {
+          capabilitiesUrl = buildCapabilitiesUrl(rawUrl);
+          currentBaseUrl = rawUrl;
+          setParam('wms', rawUrl);
+        } catch (error) {
+          showAlert('Invalid URL. Please provide a valid WMS endpoint.');
+          setStatus('Error');
+          return;
+        }
+
+        try {
+          const response = await fetch(capabilitiesUrl, { mode: 'cors' });
+          if (!response.ok) {
+            showAlert(`Fetch failed with status ${response.status} ${response.statusText}.`);
+            setStatus('Error');
+            return;
+          }
+          const text = await response.text();
+          const layers = parseCapabilities(text);
+          populateLayers(layers);
+          setStatus('Ready');
+        } catch (error) {
+          const message =
+            error instanceof TypeError
+              ? 'CORS blocked the request. Ensure the WMS server allows cross-origin access.'
+              : error.message || 'Unable to fetch GetCapabilities.';
+          showAlert(message);
+          showWarning('Tip: try opening the GetCapabilities URL in a new tab to verify access.');
+          setStatus('Error');
+        }
+      };
+
+      layerItems.addEventListener('change', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) return;
+        const index = Number(target.dataset.index);
+        const layer = currentLayers[index];
+        if (!layer) return;
+        renderLayer(layer);
+      });
+
+      loadWmsBtn.addEventListener('click', fetchCapabilities);
+      wmsUrlInput.addEventListener('change', () => {
+        setParam('wms', wmsUrlInput.value.trim());
+      });
+
+      map.on('moveend', () => {
+        const center = map.getCenter();
+        setParam('center', `${center.lng.toFixed(5)},${center.lat.toFixed(5)}`);
+        setParam('zoom', map.getZoom().toFixed(2));
+      });
+
+      map.on('load', () => {
+        restoreMapView();
+        setStatus('Idle');
+      });
+
+      const savedWms = params.get('wms');
+      if (savedWms) {
+        wmsUrlInput.value = savedWms;
+      }
+    };
+
+    const boot = async () => {
+      try {
+        const maplibregl = await loadScriptOnce(MAPLIBRE_SRC);
+        start(maplibregl);
+      } catch (error) {
+        console.error(error);
+        const alertBox = document.getElementById('alert');
+        if (alertBox) {
+          alertBox.hidden = false;
+          alertBox.textContent = 'Failed to initialize MapLibre. Check console for details.';
+        }
+      }
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', boot);
+    } else {
+      boot();
+    }
+  </script>
+</Layout>
+
+<style>
+.lab-hero{
+  text-align: center;
+  padding: var(--spacing-xl) 0 var(--spacing-lg);
+}
+.lab-kicker{
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(88,166,255,0.8);
+  margin-bottom: 8px;
+}
+.lab-title{
+  margin: 0 0 8px;
+  font-family: var(--font-display);
+  letter-spacing: 0.03em;
+}
+.lab-subtitle{
+  margin: 0 auto;
+  color: rgba(230,237,243,0.72);
+  max-width: 60ch;
+}
+.lab-actions{
+  margin-top: var(--spacing-md);
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.lab-shell{
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) 1fr;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+@media (max-width: 980px){
+  .lab-shell{ grid-template-columns: 1fr; }
+}
+
+.lab-panel{
+  border-radius: 18px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(13,17,23,0.55);
+  padding: var(--spacing-md);
+  box-shadow: 0 20px 55px rgba(0,0,0,0.28);
+}
+.lab-panel__head{
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.panel-kicker{
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(88,166,255,0.72);
+  margin: 0 0 6px;
+}
+.panel-title{
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.field-label{
+  display: block;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.lab-input,
+.lab-file{
+  width: 100%;
+  background: rgba(13,17,23,0.4);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: rgba(230,237,243,0.9);
+}
+.field-row{
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.field-row .lab-input{ flex: 1 1 220px; }
+.field-actions{ margin-top: 10px; }
+.field-hint{
+  margin-top: 8px;
+  color: rgba(230,237,243,0.55);
+  font-size: 0.85rem;
+}
+
+.lab-status{
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+  margin-top: var(--spacing-md);
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(88,166,255,0.16);
+  background: rgba(13,17,23,0.35);
+  font-size: 0.85rem;
+}
+.status-label{
+  display: block;
+  color: rgba(88,166,255,0.72);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.status-pill{
+  align-self: center;
+  justify-self: end;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(13,17,23,0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
+}
+
+.lab-alert,
+.lab-warning{
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 90, 90, 0.3);
+  background: rgba(120, 20, 20, 0.2);
+  color: rgba(255, 200, 200, 0.9);
+  font-size: 0.9rem;
+}
+.lab-warning{
+  border-color: rgba(246, 217, 110, 0.4);
+  background: rgba(60, 50, 18, 0.35);
+  color: rgba(246, 217, 110, 0.92);
+}
+
+.layer-list{
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(88,166,255,0.2);
+  background: rgba(13,17,23,0.4);
+}
+.list-title{
+  margin: 0 0 10px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(88,166,255,0.8);
+}
+.list-items{
+  display: grid;
+  gap: 8px;
+  max-height: 320px;
+  overflow: auto;
+}
+.layer-item{
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 0.9rem;
+  color: rgba(230,237,243,0.85);
+  border-radius: 10px;
+  padding: 6px 8px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(13,17,23,0.25);
+}
+.layer-item input{ accent-color: rgba(88,166,255,0.95); }
+
+.map-panel{
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(13,17,23,0.5);
+  min-height: 520px;
+}
+.map{
+  width: 100%;
+  height: 520px;
+}
+.info-panel{
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  max-width: 320px;
+  background: rgba(13,17,23,0.82);
+  border: 1px solid rgba(88,166,255,0.2);
+  border-radius: 14px;
+  padding: 12px;
+  color: rgba(230,237,243,0.85);
+  box-shadow: 0 12px 40px rgba(0,0,0,0.35);
+}
+.info-title{
+  margin: 0 0 6px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(88,166,255,0.8);
+}
+.info-content{
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+}
+</style>


### PR DESCRIPTION
### Motivation
- Make the Labs tools shareable and restorable by persisting UI state in the query string so users can bookmark or share a specific view.
- Preserve map view (center/zoom), input URLs, active tab and selected WMS layer across reloads to improve the previewing workflow.
- Surface the new GeoJSON/CSV and WMS preview tools in the Labs index and README for discoverability.

### Description
- Added URL state handling (`URLSearchParams`, `setParam`, `restoreMapView`) to `site/src/pages/labs/geojson-preview.astro` to persist and restore the active tab, `url` input, and `center`/`zoom` on map move/end and load, and to clear the param on clear.
- Added the same URL state handling to `site/src/pages/labs/wms-preview.astro` to persist `wms` endpoint, selected `layer`, and `center`/`zoom`, and to restore a previously selected layer when capabilities are populated.
- Registered both labs in `site/src/pages/labs.astro` (module cards/links) so the new pages are discoverable from the Labs index.
- Updated `README.md` to mention CSV support on the GeoJSON preview and the WMS preview layer-list feature.

### Testing
- No automated tests were executed for these UI/state-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb24c48848325a610c69e9ccb324b)